### PR TITLE
More reliable way of getting the D3D9 device

### DIFF
--- a/source/ABICompatibility.cpp
+++ b/source/ABICompatibility.cpp
@@ -1,7 +1,7 @@
 #include <Platform.hpp>
 
 // Visual Studio 2015 to Visual Studio 2022
-#if defined SYSTEM_WINDOWS && ( _MSC_VER < 1900 || _MSC_VER > 1933 )
+#if defined SYSTEM_WINDOWS && ( _MSC_VER < 1900 || _MSC_VER > 1935 )
 
 #error The only supported compilation platforms for this project on Windows are Visual Studio 2015, 2017, 2019 and 2022 (for ABI compatibility reasons).
 


### PR DESCRIPTION
The d3d9.dll pattern scan wasn't working on my computer, so I thought it would be a lot better to just pull the device pointer from the shader API instead.